### PR TITLE
fix: Statement#verifiy_certificate_chain default argument

### DIFF
--- a/lib/android_key_attestation/statement.rb
+++ b/lib/android_key_attestation/statement.rb
@@ -34,7 +34,7 @@ module AndroidKeyAttestation
         raise(ChallengeMismatchError)
     end
 
-    def verify_certificate_chain(root_certificates: GOOGLE_ROOT_CERTIFICATE, time: Time.now)
+    def verify_certificate_chain(root_certificates: GOOGLE_ROOT_CERTIFICATES, time: Time.now)
       store = OpenSSL::X509::Store.new
       root_certificates.each { |cert| store.add_cert(cert) }
       store.time = time

--- a/spec/statement_spec.rb
+++ b/spec/statement_spec.rb
@@ -35,8 +35,14 @@ RSpec.describe AndroidKeyAttestation::Statement do
     end
     let(:time) { Time.utc(2019, 12, 31) }
 
-    it "returns true if the challenge matches" do
+    it "returns true if the chain is valid" do
       expect(subject.verify_certificate_chain(root_certificates: [root_certificate], time: time)).to be true
+    end
+
+    it "raises error if the chain is not valid" do
+      expect { subject.verify_certificate_chain(time: time) }.to(
+        raise_error(AndroidKeyAttestation::CertificateVerificationError)
+      )
     end
   end
 


### PR DESCRIPTION
Fixes `uninitialized constant AndroidKeyAttestation::Statement::GOOGLE_ROOT_CERTIFICATE`