### PR TITLE
Run `rubocop` on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,13 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rspec
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '3.3'
           bundler-cache: true
       - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,6 @@ Security:
 Style/BlockComments:
   Enabled: true
 
-Style/BracesAroundHashParameters:
-  Enabled: true
-
 Style/CaseEquality:
   Enabled: true
 
@@ -181,10 +178,10 @@ Style/TrailingMethodEndStatement:
 Style/TrivialAccessors:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/UnpackFirst:
@@ -195,3 +192,6 @@ Style/YodaCondition:
 
 Style/ZeroLengthPredicate:
   Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
       pry (>= 0.13, < 0.16)
     racc (1.8.1)
     rainbow (3.1.1)
+    rexml (3.4.1)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -37,13 +38,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.5)
-    rubocop (0.75.0)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (1.6.1)
 
@@ -55,7 +57,7 @@ DEPENDENCIES
   bundler
   pry-byebug
   rspec (~> 3.8)
-  rubocop (= 0.75.0)
+  rubocop (~> 0.81.0)
 
 BUNDLED WITH
    2.7.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ DEPENDENCIES
   bundler
   pry-byebug
   rspec (~> 3.8)
-  rubocop (~> 0.81.0)
+  rubocop (~> 0.81)
 
 BUNDLED WITH
    2.7.1

--- a/android_key_attestation.gemspec
+++ b/android_key_attestation.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "~> 0.81.0"
+  spec.add_development_dependency "rubocop", "~> 0.81"
 end

--- a/android_key_attestation.gemspec
+++ b/android_key_attestation.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "0.75.0"
+  spec.add_development_dependency "rubocop", "~> 0.81.0"
 end

--- a/lib/android_key_attestation/fixed_length_secure_compare.rb
+++ b/lib/android_key_attestation/fixed_length_secure_compare.rb
@@ -6,7 +6,7 @@ module AndroidKeyAttestation
   module FixedLengthSecureCompare
     unless OpenSSL.singleton_class.method_defined?(:fixed_length_secure_compare)
       refine OpenSSL.singleton_class do
-        def fixed_length_secure_compare(a, b) # rubocop:disable Naming/UncommunicativeMethodParamName
+        def fixed_length_secure_compare(a, b) # rubocop:disable Naming/MethodParameterName:
           raise ArgumentError, "inputs must be of equal length" unless a.bytesize == b.bytesize
 
           # borrowed from Rack::Utils


### PR DESCRIPTION
>[!warning]
> ~This PR depends on #12~ 

#### Summary

- Change `rubocop` constraint to `~> 0.81.0`
- Update `rubocop`'s cops
- Run `rubocop` on the CI

